### PR TITLE
Switch Socko to use Pekko in v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## This repository is not maintained or supported by Asana, and is not accepting patches
 
 Socko is an embedded [Scala](http://www.scala-lang.org/) web server powered by
-[Netty](http://netty.io/) networking and [Akka](http://akka.io/) processing.
+[Netty](http://netty.io/) networking and [Pekko](http://pekko.apache.org/) processing.
 
 **Please see our [web site](http://sockoweb.org/) for documentaiton and more information**
 
@@ -12,7 +12,7 @@ Socko is an embedded [Scala](http://www.scala-lang.org/) web server powered by
 ```scala
     object HelloApp extends Logger {
       //
-      // STEP #1 - Define Actors and Start Akka
+      // STEP #1 - Define Actors and Start Pekko
       // See `HelloHandler`
       //
       val actorSystem = ActorSystem("HelloExampleActorSystem")

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 val shared = Seq(
   // Info
   organization := "com.github.asana.socko-asana-fork",
-  version      := "0.7.1",
+  version      := "0.8.0",
   crossScalaVersions := Seq("2.12.17", "2.13.10"),
 
   // Repositories

--- a/licenses/LICENSE.pekko.txt
+++ b/licenses/LICENSE.pekko.txt
@@ -1,8 +1,4 @@
-This software is licensed under the Apache 2 license, quoted below.
-
-Copyright 2009-2012 Typesafe Inc. [http://www.typesafe.com]
-
-Licensed under the Apache License, Version 2.0 (the "License"); you may not
+Pekko is licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
 the License at
 
@@ -13,8 +9,3 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
-
----------------
-
-Licenses for dependency projects can be found here:
-[http://akka.io/docs/akka/snapshot/project/licenses.html]

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -21,14 +21,14 @@ the License.
 Licenses for dependency projects
 ================================
 
-AKKA
+Pekko
 ----
-This product uses the Akka project:
+This product uses the Pekko project:
 
   * LICENSE FILE:
-    * LICENSE.akka.txt (Apache 2)
+    * LICENSE.pekko.txt (Apache 2)
   * HOMEPAGE:
-    * [http://akka.io/]
+    * [https://pekko.apache.org/]
     
     
 Netty

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   import Dependency._
 
   val webserver = Seq(
-    Dependency.akkaActor, Dependency.akkaSlf4j, Dependency.akkaTestKit,
+    Dependency.pekkoActor, Dependency.pekkoSlf4j, Dependency.pekkoTestKit,
     Dependency.netty, Dependency.concurrentmap, Dependency.nextProtoNeg,
     Dependency.logback, Dependency.scalatest
   )
@@ -23,7 +23,7 @@ object Dependencies {
 
   val rest = Seq(
     Dependency.json4s, Dependency.logback, 
-    Dependency.scalatest, Dependency.akkaTestKit
+    Dependency.scalatest, Dependency.pekkoTestKit
   )  
 
   val examples = Seq(
@@ -33,11 +33,11 @@ object Dependencies {
 
 object Dependency {
   object V {
-    val Akka        = "2.6.20"
+    val Pekko        = "1.0.0"
   }
-  val akkaActor     = "com.typesafe.akka"                       %% "akka-actor"                  % V.Akka
-  val akkaSlf4j     = "com.typesafe.akka"                       %% "akka-slf4j"                  % V.Akka
-  val akkaTestKit   = "com.typesafe.akka"                       %% "akka-testkit"                % V.Akka % "test"
+  val pekkoActor     = "org.apache.pekko"                       %% "pekko-actor"                  % V.Pekko
+  val pekkoSlf4j     = "org.apache.pekko"                       %% "pekko-slf4j"                  % V.Pekko
+  val pekkoTestKit   = "org.apache.pekko"                       %% "pekko-testkit"                % V.Pekko % "test"
   val ant           = "org.apache.ant"                          % "ant"                          % "1.8.4"
   val concurrentmap = "com.googlecode.concurrentlinkedhashmap"  % "concurrentlinkedhashmap-lru"  % "1.3.2"
   val logback       = "ch.qos.logback"                          % "logback-classic"              % "1.2.3" % "runtime"

--- a/socko-docs/docs/guides/basics.markdown
+++ b/socko-docs/docs/guides/basics.markdown
@@ -16,9 +16,9 @@ WebServerClass: <code><a href="../api/#org.mashupbots.socko.webserver.WebServer"
 
 Let's deep dive into the 3 steps to Socko success:
 
- - [Step 1. Define Actors and Start Akka](#Step1)
+ - [Step 1. Define Actors and Start Pekko](#Step1)
    - [Handling Socko Events](#SockoEvents)
-   - [Akka Dispatchers and Thread Pools](#AkkaDispatchers)
+   - [Pekko Dispatchers and Thread Pools](#PekkoDispatchers)
  - [Step 2. Define Routes](#Step2)
    - [Socko Event Extractors](#SockoEventExtractors)
    - [Host Extractors](#HostExtractors)
@@ -29,22 +29,22 @@ Let's deep dive into the 3 steps to Socko success:
  - [Step 3. Start/Stop Web Server](#Step3)
 
 
-## Step 1. Define Actors and Start Akka <a class="blank" id="Step1"></a>
+## Step 1. Define Actors and Start Pekko <a class="blank" id="Step1"></a>
 
-Socko assumes that you have your business rules implemented as Akka v2 Actors.
+Socko assumes that you have your business rules implemented as Pekko v2 Actors.
 
 Incoming messages received by Socko will be wrapped within a {{ page.SockoEventClass }} and passed to your routes
-for dispatching to your Akka actor handlers. Your actors use {{ page.SockoEventClass }} to read incoming data and 
+for dispatching to your Pekko actor handlers. Your actors use {{ page.SockoEventClass }} to read incoming data and 
 write outgoing data.
 
-In the following `HelloApp` example, we have defined an actor called `HelloHandler` and started an Akka
+In the following `HelloApp` example, we have defined an actor called `HelloHandler` and started an Pekko
 system called `HelloExampleActorSystem`.  The `HttpRequestEvent` is used by the `HelloHandler`
 to write a response to the client.
 
 {% highlight scala %}
     object HelloApp extends Logger {
       //
-      // STEP #1 - Define Actors and Start Akka
+      // STEP #1 - Define Actors and Start Pekko
       // See `HelloHandler`
       //
       val actorSystem = ActorSystem("HelloExampleActorSystem")
@@ -62,9 +62,9 @@ to write a response to the client.
     }
 {% endhighlight %}
     
-For maximum scalability and performance, you will need to carefully choose your Akka dispatchers.
+For maximum scalability and performance, you will need to carefully choose your Pekko dispatchers.
 The default dispatcher is optimized for non blocking code. If your code blocks though reading from and writing to 
-database and/or file system, then it is advisable to configure Akka to use dispatchers based on thread pools.
+database and/or file system, then it is advisable to configure Pekko to use dispatchers based on thread pools.
 
 ### Handling Socko Events <a class="blank" id="SockoEvents"></a>
 
@@ -128,12 +128,12 @@ There are 4 types of {{ page.SockoEventClass }}:
 All {{ page.SockoEventClass }}s must be used by **local actors** only.
 
 
-### Akka Dispatchers and Thread Pools <a class="blank" id="AkkaDispatchers"></a>
+### Pekko Dispatchers and Thread Pools <a class="blank" id="PekkoDispatchers"></a>
 
-Akka [dispatchers](http://doc.akka.io/docs/akka/2.0.1/scala/dispatchers.html) controls how your Akka 
+Pekko dispatchers controls how your Pekko 
 actors process messages.
 
-Akka's default dispatcher is optimized for non blocking code.
+Pekko's default dispatcher is optimized for non blocking code.
 
 However, if your actors have blocking operations like database read/write or file system read/write, 
 we recommend that you run these actors with a different dispatcher.  In this way, while these actors block a thread,
@@ -151,8 +151,8 @@ to allocate more threads.
         type=PinnedDispatcher
         executor=thread-pool-executor
       }
-      akka {
-        event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+      pekko {
+        event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
         loglevel=DEBUG
         actor {
           deployment {
@@ -575,7 +575,7 @@ For example, for a Scala console application:
     }
 {% endhighlight %}
 
-For a [AKKA microkernel](http://doc.akka.io/docs/akka/2.1.2/scala/microkernel.html) application:
+For a Pekko microkernel application:
 
 {% highlight scala %}
     class SockoKernel extends Bootable {

--- a/socko-docs/docs/guides/configuration.markdown
+++ b/socko-docs/docs/guides/configuration.markdown
@@ -30,7 +30,7 @@ Socko configuration settings can be grouped as:
 ## Loading Configuration
 
 Configuration can be changed in [code](https://github.com/mashupbots/socko/blob/master/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/CodedConfigApp.scala)
-or in the project's [Akka configuration file](https://github.com/mashupbots/socko/blob/master/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/AkkaConfigApp.scala).
+or in the project's [Pekko configuration file](https://github.com/mashupbots/socko/blob/master/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/PekkoConfigApp.scala).
 
 For example, to change the port from the default `8888` to `7777` in code:
 
@@ -38,27 +38,27 @@ For example, to change the port from the default `8888` to `7777` in code:
     val webServer = new WebServer(WebServerConfig(port=7777), routes)
 {% endhighlight %}
 
-To change the port to `9999` in your Akka configuration file, first define an object to load the settings
-from `application.conf`. Note the setting will be named `akka-config-example`.
+To change the port to `9999` in your Pekko configuration file, first define an object to load the settings
+from `application.conf`. Note the setting will be named `pekko-config-example`.
 
 {% highlight scala %}
     object MyWebServerConfig extends ExtensionId[WebServerConfig] with ExtensionIdProvider {
       override def lookup = MyWebServerConfig
       override def createExtension(system: ExtendedActorSystem) =
-        new WebServerConfig(system.settings.config, "akka-config-example")
+        new WebServerConfig(system.settings.config, "pekko-config-example")
     }
 {% endhighlight %}
 
 Then, start the actor system and load the configuration from that system.
 
 {% highlight scala %}
-    val actorSystem = ActorSystem("AkkaConfigActorSystem")
+    val actorSystem = ActorSystem("PekkoConfigActorSystem")
     val myWebServerConfig = MyWebServerConfig(actorSystem)
 {% endhighlight %}
     
 Lastly, add the following your `application.conf`
 
-    akka-config-example {
+    pekko-config-example {
         port=9999
     }
 
@@ -144,8 +144,8 @@ By default, web logs are turned **OFF**.
 
 To turn web logs on, add the following `web-log` section to your `application.conf`
  
-    akka-config-example {
-      server-name=AkkaConfigExample
+    pekko-config-example {
+      server-name=PekkoConfigExample
       hostname=localhost
       port=9000
       
@@ -170,14 +170,14 @@ You can also turn it on programmatically as illustrated in the [web log example 
     val webServer = new WebServer(config, routes, actorSystem)
 {% endhighlight %}
     
-When turned on, the default behaviour is to write web logs to your installed [Akka logger](http://doc.akka.io/docs/akka/2.0.1/scala/logging.html) 
-using {{ page.WebLogWriterClass }}. The Akka logger asynchronously writes to the log so it will not slow down 
+When turned on, the default behaviour is to write web logs to your installed Pekko logger
+using {{ page.WebLogWriterClass }}. The Pekko logger asynchronously writes to the log so it will not slow down 
 your application down.
 
-To activate Akka logging, add the following to `application.conf`:
+To activate Pekko logging, add the following to `application.conf`:
 
-    akka {
-      event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+    pekko {
+      event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
       loglevel = "DEBUG"
     }
 
@@ -188,7 +188,7 @@ You can configure where web logs are written by configuring your installed logge
     <configuration>
       <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-          <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{sourceThread}] %-5level %logger{36} %X{akkaSource} - %msg%n</pattern>
+          <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{sourceThread}] %-5level %logger{36} %X{pekkoSource} - %msg%n</pattern>
         </encoder>
       </appender>
 
@@ -249,12 +249,12 @@ Web log events can be recorded via the processing context.
 If you prefer to use your own method and/or format of writing web logs, you can specify the path of a custom actor 
 to recieve {{ page.WebLogEventClass }} messages in your `application.conf`.
 
-    akka-config-example {
-      server-name=AkkaConfigExample
+    pekko-config-example {
+      server-name=PekkoConfigExample
       hostname=localhost
       port=9000
       web-log {
-        custom-actor-path = "akka://my-system/user/my-web-log-writer"
+        custom-actor-path = "pekko://my-system/user/my-web-log-writer"
       }
     }
 

--- a/socko-docs/docs/guides/dynamic-content.markdown
+++ b/socko-docs/docs/guides/dynamic-content.markdown
@@ -105,8 +105,8 @@ for more details.
 
 ## RESTful Web Services <a class="blank" id="Rest"></a>
 
-Socko's {{ page.RestHandlerClass }} class provides a quick way to expose your Akka actors as REST end points. You 
-will be able to invoke your Akka actors using Javascript in a web browser app and from other HTTP clients.
+Socko's {{ page.RestHandlerClass }} class provides a quick way to expose your Pekko actors as REST end points. You 
+will be able to invoke your Pekko actors using Javascript in a web browser app and from other HTTP clients.
 
 It also natively supports [Swagger](https://developers.helloreverb.com/swagger/).  With Swagger, you will be able to 
 provide your users with your API documentation straight from your code.
@@ -168,7 +168,7 @@ The following is an example implementation of a REST operation that returns a `P
   case class GetPetRequest(context: RestRequestContext, petId: Long) extends RestRequest
   case class GetPetResponse(context: RestResponseContext, pet: Option[Pet]) extends RestResponse
 
-  class PetProcessor() extends Actor with akka.actor.ActorLogging {
+  class PetProcessor() extends Actor with org.apache.pekko.actor.ActorLogging {
     def receive = {
       case req: GetPetRequest =>
         val pet = PetData.getPetById(req.petId)
@@ -235,7 +235,7 @@ we have provided 3 example scenarios:
 In order to use {{ page.RestHandlerClass }}, you must first instance {{ page.RestRegistryClass }}. The registry 
 will search the code base for your {{ page.RestRegistrationClass }}s.
 
-Using an Akka router, you can then instance {{ page.RestHandlerClass }} with the {{ page.RestRegistryClass }}.
+Using an Pekko router, you can then instance {{ page.RestHandlerClass }} with the {{ page.RestRegistryClass }}.
 
 Finally, add the {{ page.RestHandlerClass }} to your route and start Socko web server.
 
@@ -243,11 +243,11 @@ The following example illustrates:
 
 {% highlight scala %}
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   //
   val actorConfig = """
-	akka {
-	  event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+	pekko {
+	  event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
 	  loglevel=DEBUG
 	  actor {
 	    deployment {
@@ -317,7 +317,7 @@ Required settings are:
    on the local server. It needs to take into consideration the path to {{ page.RestHandlerClass }} as set in your route. 
    In the above example, the route is set to `api` so `rootApiUrl` must be set to `http://yourdomain.com/api`.
 
-Like other settings, you can set the values programmatically or via an external Akka configuration file. See
+Like other settings, you can set the values programmatically or via an external Pekko configuration file. See
 {{ page.RestConfigClass }} for more details. 
 
 

--- a/socko-docs/docs/guides/quick-start.markdown
+++ b/socko-docs/docs/guides/quick-start.markdown
@@ -29,7 +29,7 @@ The [Quick Start](https://github.com/mashupbots/socko/tree/master/socko-examples
 example app starts a web server on `localhost:8888` that returns _"Hello from Socko"_ in response to a HTTP GET request.
 
 It illustrates the 3 steps that you have to follow to get Socko working for you.
- - [Step 1. Define Actors and Start Akka](#Step1)
+ - [Step 1. Define Actors and Start Pekko](#Step1)
  - [Step 2. Define Routes](#Step2)
  - [Step 3. Start/Stop Web Server](#Step3)
 
@@ -42,24 +42,24 @@ It illustrates the 3 steps that you have to follow to get Socko working for you.
   import org.mashupbots.socko.webserver.WebServer
   import org.mashupbots.socko.webserver.WebServerConfig
 
-  import akka.actor.ActorSystem
-  import akka.actor.Props
+  import org.apache.pekko.actor.ActorSystem
+  import org.apache.pekko.actor.Props
 
   /**
    * This example shows how to setup a simple route and create a simple processor actor.
    *  - Run this class as a Scala Application
    *  - Open your browser and navigate to `http://localhost:8888/`
    *
-   * Socko uses Netty to handle incoming requests and Akka to process them
+   * Socko uses Netty to handle incoming requests and Pekko to process them
    *  - Incoming requests are converted into Socko events using threads from the Netty thread pool
    *  - Your `routes` are then called to dispatch the event for processing
    *  - Inside our route definition, we instance a new `HelloHandler` actor and pass the event to it
-   *  - The `HelloHandler` actor is executed in Akka default thread pool. This frees up the Netty thread pool to 
+   *  - The `HelloHandler` actor is executed in Pekko default thread pool. This frees up the Netty thread pool to 
    *    undertake more networking activities.
    */
   object HelloApp extends Logger {
     //
-    // STEP #1 - Define Actors and Start Akka
+    // STEP #1 - Define Actors and Start Pekko
     // See `HelloHandler`
     //
     val actorSystem = ActorSystem("HelloExampleActorSystem")
@@ -96,7 +96,7 @@ It illustrates the 3 steps that you have to follow to get Socko working for you.
   package org.mashupbots.socko.examples.quickstart
 
   import org.mashupbots.socko.events.HttpRequestEvent
-  import akka.actor.Actor
+  import org.apache.pekko.actor.Actor
   import java.util.Date
 
   /**
@@ -112,15 +112,15 @@ It illustrates the 3 steps that you have to follow to get Socko working for you.
 {% endhighlight %}
 
 
-## Step 1. Define Actors and Start Akka <a class="blank" id="Step1"></a>
+## Step 1. Define Actors and Start Pekko <a class="blank" id="Step1"></a>
 
-Socko assumes that you have your business rules implemented as Akka v2 Actors.
+Socko assumes that you have your business rules implemented as Pekko v2 Actors.
 
 Incoming messages received by Socko will be wrapped within a {{ page.SockoEventClass }} and passed to your routes
-for dispatching to your Akka actor handlers. Your actors use {{ page.SockoEventClass }} to read incoming data and 
+for dispatching to your Pekko actor handlers. Your actors use {{ page.SockoEventClass }} to read incoming data and 
 write outgoing data.
 
-In this exmaple, we have defined an actor called `HelloHandler` and started an Akka
+In this exmaple, we have defined an actor called `HelloHandler` and started an Pekko
 system called `HelloExampleActorSystem`.  The `HttpRequestEvent` is used by the `HelloHandler`
 to write a response to the client.
     

--- a/socko-docs/docs/guides/user-guide.markdown
+++ b/socko-docs/docs/guides/user-guide.markdown
@@ -9,7 +9,7 @@ title: Socko User Guide
  - [Quick Start](quick-start.html)
 
  - [Basics](basics.html)
-   - [Step 1. Define Actors and Start Akka](basics.html#Step1)
+   - [Step 1. Define Actors and Start Pekko](basics.html#Step1)
    - [Step 2. Define Routes](basics.html#Step2)
    - [Step 3. Start/Stop Web Server](basics.html#Step3)
 

--- a/socko-examples/src/main/resources/application.conf
+++ b/socko-examples/src/main/resources/application.conf
@@ -1,13 +1,13 @@
 
-akka {
-  event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+pekko {
+  event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
   loglevel = "DEBUG"
 }
     
-akka-config-example {
+pekko-config-example {
 
   # Server Name. If omitted, the default "WebServer" will be used. 
-  server-name=AkkaConfigExample
+  server-name=PekkoConfigExample
 
   # Host name or IP address to bind to. Defaults to `localhost`.
   # Specifying `0.0.0.0` will bind to all addresses. 

--- a/socko-examples/src/main/resources/logback.xml
+++ b/socko-examples/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{sourceThread}] %-5level %logger{36} %X{akkaSource} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{sourceThread}] %-5level %logger{36} %X{pekkoSource} - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/CodedConfigApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/CodedConfigApp.scala
@@ -21,8 +21,8 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how load your web server configuration from code when instancing 
@@ -32,7 +32,7 @@ import akka.actor.Props
  */
 object CodedConfigApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `HelloHandler`
   //
   val actorSystem = ActorSystem("CodeConfigActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/PekkoConfigApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/config/PekkoConfigApp.scala
@@ -21,24 +21,24 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.ExtendedActorSystem
-import akka.actor.ExtensionId
-import akka.actor.ExtensionIdProvider
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.ExtendedActorSystem
+import org.apache.pekko.actor.ExtensionId
+import org.apache.pekko.actor.ExtensionIdProvider
+import org.apache.pekko.actor.Props
 
 /**
- * This example shows how load your web server configuration from AKKA's `application.conf`. 
+ * This example shows how load your web server configuration from Pekko's `application.conf`.
  * It is found in the root class path.  The source file is found in `src/main/resources`.
  *  - Run this class as a Scala Application
  *  - Open your browser and navigate to `http://localhost:9000/`
  */
-object AkkaConfigApp extends Logger {
+object PekkoConfigApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `HelloHandler`
   //
-  val actorSystem = ActorSystem("AkkaConfigActorSystem")
+  val actorSystem = ActorSystem("PekkoConfigActorSystem")
 
   //
   // STEP #2 - Define Routes
@@ -72,13 +72,13 @@ object AkkaConfigApp extends Logger {
 /**
  * Store of our web server configuration.
  *
- * Note that `WebServerConfig` is instanced with the setting named `akka-config-example`. This name must correspond
+ * Note that `WebServerConfig` is instanced with the setting named `pekko-config-example`. This name must correspond
  * with `application.conf`.  
  * 
  * For example:
  * {{{
- * akka-config-example {
- *   server-name=AkkaConfigExample
+ * pekko-config-example {
+ *   server-name=PekkoConfigExample
  *   hostname=localhost
  *   port=9000
  * }
@@ -87,5 +87,5 @@ object AkkaConfigApp extends Logger {
 object MyWebServerConfig extends ExtensionId[WebServerConfig] with ExtensionIdProvider {
   override def lookup = MyWebServerConfig
   override def createExtension(system: ExtendedActorSystem) =
-    new WebServerConfig(system.settings.config, "akka-config-example")
+    new WebServerConfig(system.settings.config, "pekko-config-example")
 }

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/querystring_post/QueryStringPostApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/querystring_post/QueryStringPostApp.scala
@@ -20,8 +20,8 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how to parse query string and `application/x-www-form-urlencoded` data.
@@ -30,7 +30,7 @@ import akka.actor.Props
  */
 object QueryStringPostApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   //
   val actorSystem = ActorSystem("QueryStringPostExampleActorSystem")
 

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/querystring_post/QueryStringPostHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/querystring_post/QueryStringPostHandler.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko.examples.querystring_post
 
 import org.mashupbots.socko.events.HttpRequestEvent
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import java.util.Date
 
 /**

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/quickstart/HelloApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/quickstart/HelloApp.scala
@@ -20,24 +20,24 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how to setup a simple route and create a simple processor actor.
  *  - Run this class as a Scala Application
  *  - Open your browser and navigate to `http://localhost:8888/`
  *
- * Socko uses Netty to handle incoming requests and Akka to process them
+ * Socko uses Netty to handle incoming requests and Pekko to process them
  *  - Incoming requests are converted into Socko events using threads from the Netty thread pool
  *  - Your `routes` are then called to dispatch the event for processing
  *  - Inside our route definition, we instance a new `HelloHandler` actor and pass the event to it
- *  - The `HelloHandler` actor is executed in Akka default thread pool. This frees up the Netty thread pool to 
+ *  - The `HelloHandler` actor is executed in Pekko default thread pool. This frees up the Netty thread pool to
  *    undertake more networking activities.
  */
 object HelloApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `HelloHandler`
   //
   val actorSystem = ActorSystem("HelloExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/quickstart/HelloHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/quickstart/HelloHandler.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko.examples.quickstart
 
 import org.mashupbots.socko.events.HttpRequestEvent
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import java.util.Date
 
 /**

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/routes/RouteApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/routes/RouteApp.scala
@@ -22,8 +22,8 @@ import org.mashupbots.socko.webserver.WebLogConfig
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how use route extractors.
@@ -37,7 +37,7 @@ import akka.actor.Props
  */
 object RouteApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `TimeHandler`
   //
   val actorSystem = ActorSystem("RouteExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/routes/TimeHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/routes/TimeHandler.scala
@@ -21,8 +21,8 @@ import java.util.TimeZone
 
 import org.mashupbots.socko.events.HttpRequestEvent
 
-import akka.actor.Actor
-import akka.event.Logging
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.event.Logging
 
 /**
  * Returns the current time in the response

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/routes/package.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/routes/package.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko.examples
 
 /**
- * Illustrates how to route (dispatch) requests to your Akka actors using HTTP method, host, 
+ * Illustrates how to route (dispatch) requests to your Pekko actors using HTTP method, host,
  * path and querystring.
  */
 package object routes {

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/secure/SecureApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/secure/SecureApp.scala
@@ -23,8 +23,8 @@ import org.mashupbots.socko.webserver.SslConfig
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This is a clone of the quick start `HelloApp` ... but using HTTPS.
@@ -48,7 +48,7 @@ import akka.actor.Props
  */      
 object SecureApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `HelloHandler`
   //
   val actorSystem = ActorSystem("SecureExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/secure/SecureHelloHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/secure/SecureHelloHandler.scala
@@ -19,7 +19,7 @@ import java.util.Date
 
 import org.mashupbots.socko.events.HttpRequestEvent
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 
 /**
  * Writes a greeting and terminates.

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/snoop/SnoopApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/snoop/SnoopApp.scala
@@ -21,8 +21,8 @@ import org.mashupbots.socko.routes.Routes
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how to setup a simple route and snoop actor.
@@ -31,7 +31,7 @@ import akka.actor.Props
  */
 object SnoopApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // `SnoopHandler` actor already defined.
   //
   val actorSystem = ActorSystem("SnoopExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/streaming/StreamingApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/streaming/StreamingApp.scala
@@ -20,8 +20,8 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows stream your HTTP response.
@@ -30,7 +30,7 @@ import akka.actor.Props
  */
 object StreamingApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `HelloHandler`
   //
   val actorSystem = ActorSystem("StreamingExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/streaming/StreamingHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/streaming/StreamingHandler.scala
@@ -20,7 +20,7 @@ import java.util.Date
 import io.netty.util.CharsetUtil
 import org.mashupbots.socko.events.HttpRequestEvent
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 
 /**
  * Streams a greeting and stops.

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/weblog/CustomWebLogApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/weblog/CustomWebLogApp.scala
@@ -22,22 +22,22 @@ import org.mashupbots.socko.infrastructure.WebLogFormat
 import org.mashupbots.socko.webserver.WebLogConfig
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.actorRef2Scala
-import akka.actor.Actor
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
+import org.apache.pekko.actor.actorRef2Scala
+import org.apache.pekko.actor.Actor
 
 /**
  * This example shows how to use a custom web log writer
  */
 object CustomWebLogApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   //
   // Make sure your application.conf contains:
   //
-  // akka {
-  //   event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+  // pekko {
+  //   event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
   //   loglevel = "DEBUG"
   // }  
   //

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/weblog/HelloHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/weblog/HelloHandler.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko.examples.weblog
 
 import org.mashupbots.socko.events.HttpRequestEvent
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import java.util.Date
 
 /**

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/weblog/WebLogApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/weblog/WebLogApp.scala
@@ -21,20 +21,20 @@ import org.mashupbots.socko.webserver.WebLogConfig
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how to turn on logging.
  */
 object WebLogApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // 
   // Make sure your application.conf contains:
   //
-  // akka {
-  //   event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+  // pekko {
+  //   event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
   //   loglevel = "DEBUG"
   // }  
   //

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/AutobahnApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/AutobahnApp.scala
@@ -21,8 +21,8 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example can be used to run against the Autobahn test suite
@@ -34,7 +34,7 @@ object AutobahnApp extends Logger {
   val actorSystem = ActorSystem("AutobahnActorSystem")
   
   // Instance a singleton handler so that frames are echo'ed in sequence.
-  // If we instance a new handler for each frame, Akka may not echo the incoming frames sequentially
+  // If we instance a new handler for each frame, Pekko may not echo the incoming frames sequentially
   // because instancing a new handler is not guaranteed to be sequential.
   // This is important for passing the Autobahn test suite.
   val handler = actorSystem.actorOf(Props[AutobahnHandler])

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/AutobahnHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/AutobahnHandler.scala
@@ -21,8 +21,8 @@ import java.util.GregorianCalendar
 import org.mashupbots.socko.events.HttpRequestEvent
 import org.mashupbots.socko.events.WebSocketFrameEvent
 
-import akka.actor.Actor
-import akka.event.Logging
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.event.Logging
 
 /**
  * Echo web socket frames for the Autobahn test suite

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/ChatApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/ChatApp.scala
@@ -21,10 +21,10 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.routes._
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.actorRef2Scala
-import akka.dispatch.OnComplete
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
+import org.apache.pekko.actor.actorRef2Scala
+import org.apache.pekko.dispatch.OnComplete
 
 /**
  * This example shows how to use web sockets, specifically `org.mashupbots.socko.processors.WebSocketBroadcaster`,
@@ -40,7 +40,7 @@ import akka.dispatch.OnComplete
  */
 object ChatApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // `ChatHandler` is created in the route and is self-terminating
   //
   val actorSystem = ActorSystem("ChatExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/ChatHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/ChatHandler.scala
@@ -21,9 +21,9 @@ import java.util.GregorianCalendar
 import org.mashupbots.socko.events.HttpRequestEvent
 import org.mashupbots.socko.events.WebSocketFrameEvent
 
-import akka.actor.actorRef2Scala
-import akka.actor.Actor
-import akka.event.Logging
+import org.apache.pekko.actor.actorRef2Scala
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.event.Logging
 
 /**
  * Web Socket processor for chatting

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/WebSocketApp.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/WebSocketApp.scala
@@ -21,8 +21,8 @@ import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.webserver.WebServer
 import org.mashupbots.socko.webserver.WebServerConfig
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * This example shows how to use web sockets with Socko.
@@ -34,7 +34,7 @@ import akka.actor.Props
  */
 object WebSocketApp extends Logger {
   //
-  // STEP #1 - Define Actors and Start Akka
+  // STEP #1 - Define Actors and Start Pekko
   // See `WebSocketHandler`.
   //
   val actorSystem = ActorSystem("WebSocketExampleActorSystem")

--- a/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/WebSocketHandler.scala
+++ b/socko-examples/src/main/scala/org/mashupbots/socko/examples/websocket/WebSocketHandler.scala
@@ -21,8 +21,8 @@ import java.util.GregorianCalendar
 import org.mashupbots.socko.events.HttpRequestEvent
 import org.mashupbots.socko.events.WebSocketFrameEvent
 
-import akka.actor.Actor
-import akka.event.Logging
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.event.Logging
 
 /**
  * Delivers HTML page to setup web sockets in the browser and echos incoming text frames in upper case.

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/events/HttpEventConfig.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/events/HttpEventConfig.scala
@@ -15,7 +15,7 @@
 //
 package org.mashupbots.socko.events
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 
 /**
  * HTTP event configuration used in the processing of [[org.mashupbots.socko.events.HttpEvent]]s.

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/events/WebSocketEventConfig.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/events/WebSocketEventConfig.scala
@@ -15,7 +15,7 @@
 //
 package org.mashupbots.socko.events
 
-import akka.actor.ActorRef
+import org.apache.pekko.actor.ActorRef
 import io.netty.util.AttributeKey
 
 /**

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/events/package.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/events/package.scala
@@ -17,7 +17,7 @@ package org.mashupbots.socko
 
 /**
  * Socko events are raised by Socko and passed into your routes for dispatching to your handlers.
- * Socko events provides a bridge between Netty and Akka.
+ * Socko events provides a bridge between Netty and Pekko.
  * 
  * There are 4 types of [[org.mashupbots.socko.events.SockoEvent]]
  *  - [[org.mashupbots.socko.events.HttpRequestEvent]] - Fired when a HTTP request is received

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/handlers/SnoopHandler.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/handlers/SnoopHandler.scala
@@ -26,8 +26,8 @@ import io.netty.util.AttributeKey
 import org.mashupbots.socko.events.HttpChunkEvent
 import org.mashupbots.socko.events.HttpRequestEvent
 import org.mashupbots.socko.events.WebSocketFrameEvent
-import akka.actor.Actor
-import akka.event.Logging
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.event.Logging
 import org.mashupbots.socko.events.HttpLastChunkEvent
 
 /**

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/handlers/package.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/handlers/package.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko
 
 /**
- * Handlers are Akka actors that receives and processes [[org.mashupbots.socko.events.SockoEvent]]s
+ * Handlers are Pekko actors that receives and processes [[org.mashupbots.socko.events.SockoEvent]]s
  * sent by the routes.
  * 
  * This package contains our "pre-fabricated" handlers.

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/ConfigUtil.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/ConfigUtil.scala
@@ -22,7 +22,7 @@ import com.typesafe.config.Config
 import java.util.concurrent.TimeUnit
 
 /**
- * A utility class for reading AKKA configuration
+ * A utility class for reading Pekko configuration
  */
 object ConfigUtil {
 

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/Logger.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/Logger.scala
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory
  * Adds logging functionality to our classes.
  * 
  * We try not to use this logger too often because it is synchronous. 
- * Most of Socko's logging is performed inside Akka because it is asynchronous.
+ * Most of Socko's logging is performed inside Pekko because it is asynchronous.
  * 
  * Usage:
  * {{{

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/WebLogWriter.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/WebLogWriter.scala
@@ -16,13 +16,13 @@
 
 package org.mashupbots.socko.infrastructure
 
-import akka.actor.Actor
-import akka.event.Logging
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.event.Logging
 
 /**
- * Default log writer that writes web log events to the AKKA logger.
+ * Default log writer that writes web log events to the Pekko logger.
  *
- * AKKA logger is used because it asynchronously writes to the log in a separate thread so it does not slow down
+ * Pekko logger is used because it asynchronously writes to the log in a separate thread so it does not slow down
  * your app.
  * 
  * @param format Web log format

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/package.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/package.scala
@@ -16,7 +16,7 @@
 package org.mashupbots
 
 /**
- * Socko is a Scala web server powered by Netty networking and Akka processing.
+ * Socko is a Scala web server powered by Netty networking and Pekko processing.
  * 
  * Package dependency hierarchy
  * {{{
@@ -33,7 +33,7 @@ package org.mashupbots
  *  - **infrastructure** - utility classes 
  *  - **events** - events are created by Socko and dispatched by your routes to your handlers
  *  - **routes** - extractors to assist with pattern matching in your routes
- *  - **handlers** - akka actors that executes business logic
+ *  - **handlers** - pekko actors that executes business logic
  *  - **webserver** - web server and its configuration
  */
 package object socko {

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/routes/Routes.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/routes/Routes.scala
@@ -24,7 +24,7 @@ import org.mashupbots.socko.events.WebSocketFrameEvent
 import org.mashupbots.socko.events.WebSocketHandshakeEvent
 
 /**
- * Routes define the rules for dispatching events to its intended Akka handlers. It is implemented as a
+ * Routes define the rules for dispatching events to its intended Pekko handlers. It is implemented as a
  * list of PartialFunctions.
  *
  * To assist with routing, Socko has the following extractors:

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/routes/package.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/routes/package.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko
 
 /**
- * Routes define the rules for dispatching requests to its intended Akka actor handlers.  
+ * Routes define the rules for dispatching requests to its intended Pekko actor handlers.
  */
 package object routes {
 }

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
@@ -32,8 +32,8 @@ import org.mashupbots.socko.events.SockoEvent
 import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.infrastructure.WebLogWriter
 
-import akka.actor.{ActorRefFactory, ActorRef, Props}
-import akka.util.Timeout
+import org.apache.pekko.actor.{ActorRefFactory, ActorRef, Props}
+import org.apache.pekko.util.Timeout
 
 import scala.concurrent.Await
 import scala.concurrent.duration._

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServerConfig.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServerConfig.scala
@@ -27,17 +27,17 @@ import org.mashupbots.socko.infrastructure.WebLogFormat
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 
-import akka.actor.Extension
+import org.apache.pekko.actor.Extension
 
 /**
  * Web server configuration
  *
- * The configuration can be optionally loaded from Akka's application.conf` file.
+ * The configuration can be optionally loaded from Pekko's application.conf` file.
  *
  * The following example configuration file:
  * {{{
- *   akka-config-example {
- *     server-name=AkkaConfigExample
+ *   pekko-config-example {
+ *     server-name=PekkoConfigExample
  *     hostname=localhost
  *     port=9000
  *     idle-connection-timeout=0
@@ -48,7 +48,7 @@ import akka.actor.Extension
  *
  *       # Optional path of actor to which web log events will be sent for writing. If not specified, the default
  *       # web log writer will be created
- *       custom-actor-path = "akka://my-system/user/web-log-writer"
+ *       custom-actor-path = "pekko://my-system/user/web-log-writer"
  *
  *       # Optional web log format for the default web log writer: Common, Combined or Extended.
  *       # If no specified, Common is the default.
@@ -143,7 +143,7 @@ import akka.actor.Extension
  *   object MyWebServerConfig extends ExtensionId[WebServerConfig] with ExtensionIdProvider {
  *     override def lookup = MyWebServerConfig
  *     override def createExtension(system: ExtendedActorSystem) =
- *       new WebServerConfig(system.settings.config, "akka-config-example")
+ *       new WebServerConfig(system.settings.config, "pekko-config-example")
  *   }
  *
  *   val myWebServerConfig = MyWebServerConfig(actorSystem)
@@ -180,7 +180,7 @@ case class WebServerConfig(
   tcp: TcpConfig = TcpConfig()) extends Extension {
 
   /**
-   * Read configuration from AKKA's `application.conf`
+   * Read configuration from Pekko's `application.conf`
    */
   def this(config: Config, prefix: String) = this(
     ConfigUtil.getString(config, prefix + ".server-name", "WebServer"),
@@ -277,7 +277,7 @@ case class SslConfig(
   trustStorePassword: Option[String]) {
 
   /**
-   * Read configuration from AKKA's `application.conf`
+   * Read configuration from Pekko's `application.conf`
    */
   def this(config: Config, prefix: String) = this(
     new File(config.getString(prefix + ".key-store-file")),
@@ -326,7 +326,7 @@ case class TcpConfig(
   acceptBackLog: Option[Int] = None) {
 
   /**
-   * Read configuration from AKKA's `application.conf`. Supply default values to use if setting not present
+   * Read configuration from Pekko's `application.conf`. Supply default values to use if setting not present
    */
   def this(config: Config, prefix: String) = this(
     ConfigUtil.getOptionalBoolean(config, prefix + ".no-delay"),
@@ -372,7 +372,7 @@ case class HttpConfig(
   val maxLengthInBytes = maxLengthInMB * 1024 * 1024
 
   /**
-   * Read configuration from AKKA's `application.conf`. Supply default values to use if setting not present
+   * Read configuration from Pekko's `application.conf`. Supply default values to use if setting not present
    */
   def this(config: Config, prefix: String) = this(
     ConfigUtil.getInt(config, prefix + ".max-length-in-mb", 4),
@@ -398,7 +398,7 @@ case class WebLogConfig(
   format: WebLogFormat.Value = WebLogFormat.Common) {
 
   /**
-   * Read configuration from AKKA's `application.conf`
+   * Read configuration from Pekko's `application.conf`
    */
   def this(config: Config, prefix: String) = this(
     ConfigUtil.getOptionalString(config, prefix + ".custom-actor-path"),
@@ -406,7 +406,7 @@ case class WebLogConfig(
 }
 
 /**
- * Methods for reading configuration from Akka.
+ * Methods for reading configuration from Pekko.
  */
 object WebServerConfig extends Logger {
   

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/package.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/package.scala
@@ -16,7 +16,7 @@
 package org.mashupbots.socko
 
 /**
- * Socko web server built on top of Netty networking and Akka processing.
+ * Socko web server built on top of Netty networking and Pekko processing.
  */
 package object webserver {
 }

--- a/socko-webserver/src/test/resources/logback-test.xml
+++ b/socko-webserver/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%-5level] [%thread] [%X{sourceThread}] [%logger{36}] [%X{akkaSource}] - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%-5level] [%thread] [%X{sourceThread}] [%logger{36}] [%X{pekkoSource}] - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/SnoopSpec.scala
+++ b/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/SnoopSpec.scala
@@ -34,20 +34,20 @@ import org.scalatest.GivenWhenThen
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import com.typesafe.config.ConfigFactory
-import akka.actor.actorRef2Scala
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.actorRef2Scala
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 class SnoopSpec extends WordSpec with Matchers with BeforeAndAfterAll with GivenWhenThen with TestHttpClient {
 
-  val akkaConfig =
+  val pekkoConfig =
     """
-      akka {
-        event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+      pekko {
+        event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
         loglevel = "DEBUG"
 	  }    
     """
-  val actorSystem = ActorSystem("SnoopActorSystem", ConfigFactory.parseString(akkaConfig))
+  val actorSystem = ActorSystem("SnoopActorSystem", ConfigFactory.parseString(pekkoConfig))
   var webServer: WebServer = null
   val port = 9000
   val path = "http://localhost:" + port + "/"

--- a/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/WebSocketBroadcastSpec.scala
+++ b/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/WebSocketBroadcastSpec.scala
@@ -30,22 +30,22 @@ import org.scalatest.Matchers
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * Test broadcast.  Need its own test so that broadcast does not interfere with other tests 
  */
 class WebSocketBroadcastSpec extends WordSpec with Matchers with BeforeAndAfterAll with GivenWhenThen with TestHttpClient {
 
-  val akkaConfig =
+  val pekkoConfig =
     """
-      akka {
-        event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+      pekko {
+        event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
         loglevel = "DEBUG"
 	  }    
     """
-  val actorSystem = ActorSystem("WsBroadcastActorSystem", ConfigFactory.parseString(akkaConfig))
+  val actorSystem = ActorSystem("WsBroadcastActorSystem", ConfigFactory.parseString(pekkoConfig))
   var webServer: WebServer = null
   val port = 9003
   val path = "http://localhost:" + port + "/"

--- a/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/WebSocketIdleTimeoutSpec.scala
+++ b/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/WebSocketIdleTimeoutSpec.scala
@@ -32,22 +32,22 @@ import org.scalatest.Matchers
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * Test broadcast.  Need its own test so that broadcast does not interfere with other tests 
  */
 class WebSocketIdleTimeoutSpec extends WordSpec with Matchers with BeforeAndAfterAll with GivenWhenThen with TestHttpClient {
 
-  val akkaConfig =
+  val pekkoConfig =
     """
-      akka {
-        event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+      pekko {
+        event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
         loglevel = "DEBUG"
 	  }    
     """
-  val actorSystem = ActorSystem("IdleTimeoutActorSystem", ConfigFactory.parseString(akkaConfig))
+  val actorSystem = ActorSystem("IdleTimeoutActorSystem", ConfigFactory.parseString(pekkoConfig))
   var webServer: WebServer = null
   val port = 9004
   val path = "http://localhost:" + port + "/"

--- a/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/WebSocketSpec.scala
+++ b/socko-webserver/src/test/scala/org/mashupbots/socko/handlers/WebSocketSpec.scala
@@ -30,8 +30,8 @@ import org.scalatest.Matchers
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.Props
 
 /**
  * Basic web socket tests performed in SnoopSpec.
@@ -40,14 +40,14 @@ import akka.actor.Props
  */
 class WebSocketSpec extends WordSpec with Matchers with BeforeAndAfterAll with GivenWhenThen with TestHttpClient {
 
-  val akkaConfig =
+  val pekkoConfig =
     """
-      akka {
-        event-handlers = ["akka.event.slf4j.Slf4jEventHandler"]
+      pekko {
+        event-handlers = ["org.apache.pekko.event.slf4j.Slf4jEventHandler"]
         loglevel = "DEBUG"
 	  }    
     """
-  val actorSystem = ActorSystem("WsActorSystem", ConfigFactory.parseString(akkaConfig))
+  val actorSystem = ActorSystem("WsActorSystem", ConfigFactory.parseString(pekkoConfig))
   var webServer: WebServer = null
   val port = 9002
   val path = "http://localhost:" + port + "/"

--- a/socko-webserver/src/test/scala/org/mashupbots/socko/webserver/WebServerConfigSpec.scala
+++ b/socko-webserver/src/test/scala/org/mashupbots/socko/webserver/WebServerConfigSpec.scala
@@ -28,10 +28,10 @@ import org.scalatest.Matchers
 
 import com.typesafe.config.ConfigFactory
 
-import akka.actor.ActorSystem
-import akka.actor.ExtendedActorSystem
-import akka.actor.ExtensionId
-import akka.actor.ExtensionIdProvider
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.actor.ExtendedActorSystem
+import org.apache.pekko.actor.ExtensionId
+import org.apache.pekko.actor.ExtensionIdProvider
 
 class WebServerConfigSpec extends WordSpec with Matchers with GivenWhenThen with BeforeAndAfterAll {
 
@@ -186,7 +186,7 @@ class WebServerConfigSpec extends WordSpec with Matchers with GivenWhenThen with
         WebServerConfig(http = HttpConfig(1, 1, 0, -1, false)), "HTTP configuration, maximum chunk size")
     }
 
-    "load from Akka Config" in {
+    "load from Pekko Config" in {
 
       // *** If you are changing this, review scaladoc of WebServerConfig ***
       val actorConfig = """
@@ -199,7 +199,7 @@ class WebServerConfigSpec extends WordSpec with Matchers with GivenWhenThen with
           idle-connection-timeout=30 seconds
           log-network-activity=true
           web-log {
-            custom-actor-path = "akka://my-system/user/web-log-writer"
+            custom-actor-path = "pekko://my-system/user/web-log-writer"
             format = Extended
           }
 		  ssl {
@@ -265,7 +265,7 @@ class WebServerConfigSpec extends WordSpec with Matchers with GivenWhenThen with
       all.logNetworkActivity should be(true)
 
       all.webLog.get.format should be(WebLogFormat.Extended)
-      all.webLog.get.customActorPath.get should be("akka://my-system/user/web-log-writer")
+      all.webLog.get.customActorPath.get should be("pekko://my-system/user/web-log-writer")
 
       all.ssl.get.keyStoreFile.getAbsolutePath should equal("/tmp/ks.dat")
       all.ssl.get.keyStorePassword should equal("kspwd")


### PR DESCRIPTION
My strategy here was just to find-replace until there were no occurences of "akka" left in the repo. Followed this migration guide: https://pekko.apache.org/docs/pekko/current/project/migration-guides.html

Testing:
- `sbt + test`
- I will publish this and load it in codez on a test branch using Pekko, and test it works there.

cc @ramatevish @bibachhetri 